### PR TITLE
fix: make everything work with no_std

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -54,6 +54,9 @@ impl fmt::Display for ConversionError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ConversionError {}
+
 impl TryFrom<Ipld> for () {
     type Error = ConversionError;
 
@@ -208,7 +211,7 @@ derive_try_from_ipld_option!(Link, Cid);
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::BTreeMap;
+    use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
 
     use cid::Cid;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,6 +2,7 @@
 /// Construct an `Ipld` from a literal.
 ///
 /// ```edition2018
+/// # extern crate alloc;
 /// # use ipld_core::ipld;
 /// #
 /// let value = ipld!({
@@ -24,6 +25,7 @@
 /// map with non-string keys, the `json!` macro will panic.
 ///
 /// ```edition2018
+/// # extern crate alloc;
 /// # use ipld_core::ipld;
 /// #
 /// let code = 200;
@@ -41,6 +43,7 @@
 /// Trailing commas are allowed inside both arrays and objects.
 ///
 /// ```edition2018
+/// # extern crate alloc;
 /// # use ipld_core::ipld;
 /// #
 /// let value = ipld!([
@@ -250,12 +253,12 @@ macro_rules! ipld_internal {
     };
 
     ({}) => {
-        $crate::ipld::Ipld::Map(std::collections::BTreeMap::new())
+        $crate::ipld::Ipld::Map(alloc::collections::BTreeMap::new())
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::ipld::Ipld::Map({
-            let mut object = std::collections::BTreeMap::new();
+            let mut object = alloc::collections::BTreeMap::new();
             ipld_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })
@@ -277,7 +280,7 @@ macro_rules! ipld_internal {
 #[doc(hidden)]
 macro_rules! ipld_internal_vec {
     ($($content:tt)*) => {
-        vec![$($content)*]
+        alloc::vec![$($content)*]
     };
 }
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -37,9 +37,8 @@ impl serde::ser::StdError for SerdeError {}
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::convert::TryFrom;
-    use std::fmt;
+    use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
+    use core::fmt;
 
     use cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
     use cid::Cid;


### PR DESCRIPTION
It was just a matter of different imports, to make all of th the code work with `no_std`. The `std` feature now only makes sure that the errors implement `std::error::Error`.

Also add missing `std::error::Error` implementation for `ConversionError`.