### PR TITLE
fix: make ipld macro really work with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,11 @@ mod arb;
 mod macros;
 
 pub use cid;
+
+// This is a hack to get those types working in the `ipld!` macro with and without `no_std`. The
+// idea is from
+// https://stackoverflow.com/questions/71675411/refer-to-an-extern-crate-in-macro-expansion/71675639#71675639
+#[doc(hidden)]
+pub mod __private_do_not_use {
+    pub use alloc::{collections::BTreeMap, vec};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -253,12 +253,12 @@ macro_rules! ipld_internal {
     };
 
     ({}) => {
-        $crate::ipld::Ipld::Map(alloc::collections::BTreeMap::new())
+        $crate::ipld::Ipld::Map($crate::__private_do_not_use::BTreeMap::new())
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::ipld::Ipld::Map({
-            let mut object = alloc::collections::BTreeMap::new();
+            let mut object = $crate::__private_do_not_use::BTreeMap::new();
             ipld_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })
@@ -280,7 +280,7 @@ macro_rules! ipld_internal {
 #[doc(hidden)]
 macro_rules! ipld_internal_vec {
     ($($content:tt)*) => {
-        alloc::vec![$($content)*]
+        $crate::__private_do_not_use::vec![$($content)*]
     };
 }
 
@@ -288,32 +288,4 @@ macro_rules! ipld_internal_vec {
 #[doc(hidden)]
 macro_rules! ipld_unexpected {
     () => {};
-}
-
-#[cfg(test)]
-mod tests {
-    use cid::Cid;
-
-    use crate::ipld::Ipld;
-
-    #[test]
-    fn test_macro() {
-        let _: Ipld = ipld!(null);
-        let _: Ipld = ipld!(true);
-        let _: Ipld = ipld!(false);
-        let _: Ipld = ipld!(1);
-        let _: Ipld = ipld!(1.0);
-        let a: Ipld = ipld!("string");
-        let _: Ipld = ipld!([]);
-        let _: Ipld = ipld!([1, 2, 3]);
-        let _: Ipld = ipld!({});
-        let _: Ipld = ipld!({
-            "bye": null,
-            "numbers": [1, 2, 3],
-            "a": a,
-        });
-        let cid =
-            Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
-        let _: Ipld = ipld!(cid);
-    }
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,21 @@
+use ipld_core::{cid::Cid, ipld, ipld::Ipld};
+
+#[test]
+fn test_macro() {
+    let _: Ipld = ipld!(null);
+    let _: Ipld = ipld!(true);
+    let _: Ipld = ipld!(false);
+    let _: Ipld = ipld!(1);
+    let _: Ipld = ipld!(1.0);
+    let a: Ipld = ipld!("string");
+    let _: Ipld = ipld!([]);
+    let _: Ipld = ipld!([1, 2, 3]);
+    let _: Ipld = ipld!({});
+    let _: Ipld = ipld!({
+        "bye": null,
+        "numbers": [1, 2, 3],
+        "a": a,
+    });
+    let cid = Cid::try_from("bafkreie74tgmnxqwojhtumgh5dzfj46gi4mynlfr7dmm7duwzyvnpw7h7m").unwrap();
+    let _: Ipld = ipld!(cid);
+}


### PR DESCRIPTION
Just using `alloc` within the macro doesn't work when the `ipld!` macro is used outside of this crate. The reason is that `extern crate alloc` would need to be specified in the consuming crate. We cannot guarantee that. It could result in errors like:

    error[E0433]: failed to resolve: use of undeclared crate or module `alloc`

A workaround based on [1] is to bring the types from `alloc` that we need into the scope of the crate and then refer to those from within the macro.

Move the macro tests from unit tests to integration tests to make sure such problems won't arise again, as now the `ipld!` macro is used from an external crate.

[1]: https://stackoverflow.com/questions/71675411/refer-to-an-extern-crate-in-macro-expansion/71675639#71675639