### PR TITLE
feat: add Codec trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "encoding"]
 
 [features]
 default = ["std"]
-# Makes the error implement `std::error::Error`.
+# Makes the error implement `std::error::Error` and the `Codec` trait available.
 std = ["cid/std", "serde?/std"]
 # Enables support for Serde serialization into/deserialization from the `Ipld` enum.
 serde = ["dep:serde", "cid/serde-codec"]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -25,5 +25,5 @@ pub trait Links {
     type LinksError;
 
     /// Return all links (CIDs) that the given encoded data contains.
-    fn links(bytes: &[u8]) -> Result<Vec<Cid>, Self::LinksError>;
+    fn links(bytes: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError>;
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -7,7 +7,7 @@ use cid::Cid;
 
 /// Each IPLD codec implementation should implement this Codec trait. This way codecs can be more
 /// easily exchanged or combined.
-pub trait Codec<T> {
+pub trait Codec<T>: Links {
     /// The multicodec code of the IPLD codec.
     const CODE: u64;
     /// The error that is returned if encoding or decoding fails.
@@ -22,8 +22,8 @@ pub trait Codec<T> {
 /// Trait for returning the links of a serialized IPLD data.
 pub trait Links {
     /// The error that is returned if the link extraction fails.
-    type Error;
+    type LinksError;
 
     /// Return all links (CIDs) that the given encoded data contains.
-    fn links(bytes: &[u8]) -> Result<Vec<Cid>, Self::Error>;
+    fn links(bytes: &[u8]) -> Result<Vec<Cid>, Self::LinksError>;
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -5,6 +5,8 @@
 
 use cid::Cid;
 
+use std::io::{BufRead, Write};
+
 /// Each IPLD codec implementation should implement this Codec trait. This way codecs can be more
 /// easily exchanged or combined.
 pub trait Codec<T>: Links {
@@ -13,10 +15,22 @@ pub trait Codec<T>: Links {
     /// The error that is returned if encoding or decoding fails.
     type Error;
 
+    /// Decode a reader into the desired type.
+    fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error>;
+    /// Encode a type into a writer.
+    fn encode<W: Write>(writer: W, data: &T) -> Result<(), Self::Error>;
+
     /// Decode a slice into the desired type.
-    fn decode(bytes: &[u8]) -> Result<T, Self::Error>;
+    fn decode_from_slice(bytes: &[u8]) -> Result<T, Self::Error> {
+        Self::decode(bytes)
+    }
+
     /// Encode a type into bytes.
-    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error>;
+    fn encode_to_vec(data: &T) -> Result<Vec<u8>, Self::Error> {
+        let mut output = Vec::new();
+        Self::encode(&mut output, data)?;
+        Ok(output)
+    }
 }
 
 /// Trait for returning the links of a serialized IPLD data.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,29 @@
+//! This module contains traits to have a unified API across codecs.
+//!
+//! There are two traits defined, [`Codec`] and [`Links`]. Those are separate traits as the `Links`
+//! trait is not generic over a certain type.
+
+use cid::Cid;
+
+/// Each IPLD codec implementation should implement this Codec trait. This way codecs can be more
+/// easily exchanged or combined.
+pub trait Codec<T> {
+    /// The multicodec code of the IPLD codec.
+    const CODE: u64;
+    /// The error that is returned if encoding or decoding fails.
+    type Error;
+
+    /// Decode a slice into the desired type.
+    fn decode(bytes: &[u8]) -> Result<T, Self::Error>;
+    /// Encode a type into bytes.
+    fn encode(obj: &T) -> Result<Vec<u8>, Self::Error>;
+}
+
+/// Trait for returning the links of a serialized IPLD data.
+pub trait Links {
+    /// The error that is returned if the link extraction fails.
+    type Error;
+
+    /// Return all links (CIDs) that the given encoded data contains.
+    fn links(bytes: &[u8]) -> Result<Vec<Cid>, Self::Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate alloc;
 
+#[cfg(feature = "std")]
 pub mod codec;
 pub mod convert;
 pub mod ipld;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate alloc;
 
+pub mod codec;
 pub mod convert;
 pub mod ipld;
 #[cfg(feature = "serde")]


### PR DESCRIPTION
With the `Codec` trait it's now possible to have a unified API to encode and decode data across different codecs.

Th accompanying `Links` trait allows to extract all the links (CIDs) from some encoded IPLD data.

For examples of its implementation see:

 - https://github.com/ipld/serde_ipld_dagcbor/pull/28
 - https://github.com/ipld/serde_ipld_dagjson/pull/2
 - https://github.com/ipld/rust-ipld-dagpb/pull/2