### PR TITLE
fix: make sure extracting links works without default features

### DIFF
--- a/src/serde/extract_links.rs
+++ b/src/serde/extract_links.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use core::fmt;
 
 use cid::CidGeneric;


### PR DESCRIPTION
When compiles without default features, it failes due to `Vec` and `vec!` not being defined. Importing them from alloc makes it work.