### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
 ]
 repository = "https://github.com/ipld/rust-ipld-core"
 edition = "2021"
+rust-version = "1.75.0"
 description = "IPLD core types"
 license = "MIT OR Apache-2.0"
 categories = ["data-structures", "encoding"]


### PR DESCRIPTION
This is to specify that the MSRV (minimum support rust version) of this library is `1.75.0`.

Builds will fail with rustc versions older than 1.74.

```
$ cargo +1.74 build
   Compiling ipld-core v0.3.2 ...
error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
  --> src/codec.rs:42:38
   |
42 |     fn links(bytes: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError>;
   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information

For more information about this error, try `rustc --explain E0562`.
error: could not compile `ipld-core` (lib) due to previous error
```

The return position `impl Trait` pointed out here is from 1.75 to stable.
https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html

I have MSRV 1.70 in my library ATrium, in which case it turns out that I cannot use this library or serde-ipld-dagcbor 0.5, which depends on it.
It would be helpful information for developers like me if that is explicitly stated in the `rust-version`.