### PR TITLE
fix: lower the required MSRV

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -39,5 +39,5 @@ pub trait Links {
     type LinksError;
 
     /// Return all links (CIDs) that the given encoded data contains.
-    fn links(bytes: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError>;
+    fn links(bytes: &[u8]) -> Result<Box<dyn Iterator<Item = Cid>>, Self::LinksError>;
 }


### PR DESCRIPTION
For discussion about why this PR exists, please see https://github.com/ipld/rust-ipld-core/issues/13

---

Returning an impl trait from a trait was introduced in Rust 1.75. In order to support lower MSRV, change it to a boxed trait.

BREAKING CHANGE: The return value of `Links::links` changed from

    Result<impl Iterator<Item = Cid>, Self::LinksError>

to

    Result<Box<dyn Iterator<Item = Cid>>, Self::LinksError>
