### PR TITLE
fix: introduce `codec` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,15 @@ license = "MIT OR Apache-2.0"
 categories = ["data-structures", "encoding"]
 
 [features]
-default = ["std"]
+default = ["codec", "std"]
 # Makes the error implement `std::error::Error` and the `Codec` trait available.
 std = ["cid/std", "serde?/std", "serde_bytes?/std"]
 # Enables support for Serde serialization into/deserialization from the `Ipld` enum.
 serde = ["dep:serde", "dep:serde_bytes", "cid/serde"]
 # Enables support for property based testing.
 arb = ["dep:quickcheck", "cid/arb"]
+# Enables support for the Codec trait, needs at least Rust 1.75
+codec = []
 
 [dependencies]
 cid = { version = "0.11.1", default-features = false, features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ fn main() {
 Feature flags
 -------------
 
- - `std`: Makes the error implement `std::error::Error` and the `Codec` trait available.
+ - `std` (enabled by default): Makes the error implement `std::error::Error` and the `Codec` trait available.
+ - `codec` (enabled by default): Provides the `Codec` trait, which enables encoding and decoding independent of the IPLD Codec. The minimum supported Rust version (MSRV) can significantly be reduced to 1.64 by disabling this feature.
  - `serde`: Enables support for Serde serialization into/deserialization from the `Ipld` enum.
  - `arb`: Enables support for property based testing.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "codec"))]
 pub mod codec;
 pub mod convert;
 pub mod ipld;


### PR DESCRIPTION
The `Link` trait needs at least Rust version 1.75. This commit introduces a `codec` feature flag, so that lower versions of Rust can be supported, in case no `Codec` trait implementation is needed.

Fixes #13.

---

@Stebalien This needs a new minor release (once merged) as it could technically break things for people that use `default-features = false`, right?