### PR TITLE
chore: update dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,16 @@ jobs:
       - name: Build
         # `thumbv6m-none-eabi` can't be used as Serde doesn't compile there.
         run: cargo build --no-default-features --features serde
+
+  check-lockfile:
+    name: Make sure the lockfile is up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Error if checked-in lockfile is not up-to-date
+        run: cargo build --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,17 +113,6 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11e58f441b08619fccfa54c237d418b8937e29407e36c57e60ac2bc0bd1c75e"
-dependencies = [
- "cid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ipld-core"
 version = "0.4.0"
 dependencies = [
  "cid",
@@ -323,23 +312,23 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e0bd7befb28ff014740ae0d0969b1ec6deaa82f34d1ddf0285bcbf9857dbe"
+checksum = "bb1eedfc9e48051a90d79e189dea2303b7c0df82f03e154ae85bf2ceea957972"
 dependencies = [
  "cbor4ii",
- "ipld-core 0.3.2",
+ "ipld-core",
  "scopeguard",
  "serde",
 ]
 
 [[package]]
 name = "serde_ipld_dagjson"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f40f1176e9b83724e4fe5778dbd7878e2ffd5bce7edbc66e7a76db4e1da51a5"
+checksum = "3359b47ba7f4a306ef5984665e10539e212e97217afa489437d533208eecda36"
 dependencies = [
- "ipld-core 0.3.2",
+ "ipld-core",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_bytes = { version = "0.11.5", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0.197"
-serde_ipld_dagcbor = "0.5.0"
-serde_ipld_dagjson = "0.1.2"
+serde_ipld_dagcbor = "0.6.0"
+serde_ipld_dagjson = "0.2.0"
 serde_json = "1.0.79"
 serde_test = "1.0.132"
 


### PR DESCRIPTION
Update the dev dependencies to the newest version so that the tests pass again. This is an issue whenever there is a breaking release of `ipld-core`. On the other hand it makes sure that we won't forget to update `serde_ipld_dagcbor` and `serde_ipld_dagjson` to the latest version of `ipld-core` after a release.

It also adds a CI job to make sure the checked-in Cargo.lock file is up-to-date.