### PR TITLE
Make `Codec`s composable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -66,15 +66,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c01c06f5f429efdf2bae21eb67c28b3df3cf85b7dd2d8ef09c0838dac5d33e"
+checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
+checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -127,28 +127,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipld-core"
+version = "0.4.1"
+source = "git+https://github.com/expede/rust-ipld-core?branch=compose-codecs#4ec9d497f4bc8ec408b6319d52d036fca7194ec0"
+dependencies = [
+ "cid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "multibase"
@@ -183,9 +193,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -203,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -242,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -254,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -265,15 +275,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -283,41 +293,40 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1eedfc9e48051a90d79e189dea2303b7c0df82f03e154ae85bf2ceea957972"
+version = "0.6.1"
+source = "git+https://github.com/expede/serde_ipld_dagcbor?branch=from_u64#7244516f85046dc8859497bb980d1bd82c5f3052"
 dependencies = [
  "cbor4ii",
- "ipld-core",
+ "ipld-core 0.4.1 (git+https://github.com/expede/rust-ipld-core?branch=compose-codecs)",
  "scopeguard",
  "serde",
 ]
@@ -325,19 +334,18 @@ dependencies = [
 [[package]]
 name = "serde_ipld_dagjson"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3359b47ba7f4a306ef5984665e10539e212e97217afa489437d533208eecda36"
+source = "git+https://github.com/expede/serde_ipld_dagjson?branch=update-codec#52b43c817d7bc1a673bcb1f12b2afc7c5cef9a81"
 dependencies = [
- "ipld-core",
+ "ipld-core 0.4.1 (git+https://github.com/expede/rust-ipld-core?branch=compose-codecs)",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",
@@ -366,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "ipld-core"
 version = "0.4.1"
-source = "git+https://github.com/expede/rust-ipld-core?branch=compose-codecs#4ec9d497f4bc8ec408b6319d52d036fca7194ec0"
+source = "git+https://github.com/expede/rust-ipld-core?branch=compose-codecs#323e77903e1a3f33d5bb978e3ef2c902a30966c0"
 dependencies = [
  "cid",
  "serde",
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 name = "serde_ipld_dagjson"
 version = "0.2.0"
-source = "git+https://github.com/expede/serde_ipld_dagjson?branch=update-codec#52b43c817d7bc1a673bcb1f12b2afc7c5cef9a81"
+source = "git+https://github.com/expede/serde_ipld_dagjson?branch=update-codec#021b0ef2321b1bedaef918d287758104e8477c8b"
 dependencies = [
  "ipld-core 0.4.1 (git+https://github.com/expede/rust-ipld-core?branch=compose-codecs)",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_bytes = { version = "0.11.5", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0.197"
-serde_ipld_dagcbor = "0.6.0"
-serde_ipld_dagjson = "0.2.0"
+serde_ipld_dagcbor = { version = "0.6.0", git = "https://github.com/expede/serde_ipld_dagcbor", branch = "from_u64" }
+serde_ipld_dagjson = { version = "0.2.0", git = "https://github.com/expede/serde_ipld_dagjson", branch = "update-codec" }
 serde_json = "1.0.79"
 serde_test = "1.0.132"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_bytes = { version = "0.11.5", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0.197"
-serde_ipld_dagcbor = { version = "0.6.0", git = "https://github.com/expede/serde_ipld_dagcbor", branch = "from_u64" }
-serde_ipld_dagjson = { version = "0.2.0", git = "https://github.com/expede/serde_ipld_dagjson", branch = "update-codec" }
+serde_ipld_dagcbor = { version = "*", git = "https://github.com/expede/serde_ipld_dagcbor", branch = "from_u64" }
+serde_ipld_dagjson = { version = "*", git = "https://github.com/expede/serde_ipld_dagjson", branch = "update-codec" }
 serde_json = "1.0.79"
 serde_test = "1.0.132"
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ struct Tree {
     age: u8,
 }
 
-fn encode_generic<C, T>(codec: C, value: &T) -> Result<Vec<u8>, C::Error>
-where
-    C: Codec<T>,
+fn encode_generic<C: Codec<T>, T>(codec: C, value: &T) -> Result<Vec<u8>, C::Error>
 {
     codec.encode_to_vec(value)
 }
@@ -45,7 +43,7 @@ fn main() {
         age: 91,
     };
 
-    let cbor_encoded = encode_generic(DagCborCodec, &tree);
+    let cbor_encoded = encode_generic::<DagCborCodec, Tree>(DagCborCodec, &tree);
     #[allow(clippy::format_collect)]
     let cbor_hex = cbor_encoded
         .unwrap()
@@ -65,7 +63,7 @@ fn main() {
 If you are only interested in the links (CIDs) of an encoded IPLD object, then you can extract them them directly with [`Codec::links()`]:
 
 ```rust
-use ipld_core::{codec::{Codec, Links}, ipld, cid::Cid};
+use ipld_core::{codec::{Codec, Links}, ipld, ipld::Ipld, cid::Cid};
 use serde_ipld_dagjson::codec::DagJsonCodec;
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's a full example of a function that can encode data with both [serde_ipld_d
 ```rust
 use std::str;
 
-use ipld_core::codec::Codec;
+use ipld_core::codec::{Codec, Links};
 use serde::{Deserialize, Serialize};
 use serde_ipld_dagcbor::codec::DagCborCodec;
 use serde_ipld_dagjson::codec::DagJsonCodec;
@@ -32,11 +32,11 @@ struct Tree {
     age: u8,
 }
 
-fn encode_generic<C, T>(value: &T) -> Result<Vec<u8>, C::Error>
+fn encode_generic<C, T>(codec: C, value: &T) -> Result<Vec<u8>, C::Error>
 where
     C: Codec<T>,
 {
-    C::encode_to_vec(value)
+    codec.encode_to_vec(value)
 }
 
 fn main() {
@@ -45,7 +45,7 @@ fn main() {
         age: 91,
     };
 
-    let cbor_encoded = encode_generic::<DagCborCodec, _>(&tree);
+    let cbor_encoded = encode_generic(DagCborCodec, &tree);
     #[allow(clippy::format_collect)]
     let cbor_hex = cbor_encoded
         .unwrap()
@@ -54,7 +54,7 @@ fn main() {
         .collect::<String>();
     // CBOR encoded: https://cbor.nemo157.com/#value=a2666865696768740c63616765185b
     println!("CBOR encoded: https://cbor.nemo157.com/#value={}", cbor_hex);
-    let json_encoded = encode_generic::<DagJsonCodec, _>(&tree).unwrap();
+    let json_encoded = encode_generic(DagJsonCodec, &tree).unwrap();
     // JSON encoded: {"height":12,"age":91}
     println!("JSON encoded: {}", str::from_utf8(&json_encoded).unwrap());
 }
@@ -73,9 +73,9 @@ fn main() {
     let data = ipld!({"some": {"nested": cid}, "or": [cid, cid], "more": true});
 
     let mut encoded = Vec::new();
-    DagJsonCodec::encode(&mut encoded, &data).unwrap();
+    DagJsonCodec.encode(&mut encoded, &data).unwrap();
 
-    let links = DagJsonCodec::links(&encoded).unwrap().collect::<Vec<_>>();
+    let links = DagJsonCodec.links(&encoded).unwrap().collect::<Vec<_>>();
     // Extracted links: [Cid(bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy), Cid(bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy), Cid(bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy)]
     println!("Extracted links: {:?}", links);
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -24,14 +24,14 @@ pub trait Codec<T>: Links {
     fn encode<W: Write>(&self, writer: W, data: &T) -> Result<(), Self::Error>;
 
     /// Decode a slice into the desired type.
-    fn decode_from_slice(bytes: &[u8]) -> Result<T, Self::Error> {
-        Self::decode(bytes)
+    fn decode_from_slice(&self, bytes: &[u8]) -> Result<T, Self::Error> {
+        self.decode(bytes)
     }
 
     /// Encode a type into bytes.
-    fn encode_to_vec(data: &T) -> Result<Vec<u8>, Self::Error> {
+    fn encode_to_vec(&self, data: &T) -> Result<Vec<u8>, Self::Error> {
         let mut output = Vec::new();
-        Self::encode(&mut output, data)?;
+        self.encode(&mut output, data)?;
         Ok(output)
     }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -10,10 +10,13 @@ use std::io::{BufRead, Write};
 /// Each IPLD codec implementation should implement this Codec trait. This way codecs can be more
 /// easily exchanged or combined.
 pub trait Codec<T>: Links {
-    /// The multicodec code of the IPLD codec.
-    const CODE: u64;
     /// The error that is returned if encoding or decoding fails.
     type Error;
+
+    /// The multicodec code of the IPLD codec.
+    fn to_code(&self) -> u64;
+    /// Attempt to convert from a `u64` code to this `Codec`.
+    fn try_from_code(code: u64) -> Option<Self> where Self: Sized;
 
     /// Decode a reader into the desired type.
     fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error>;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -19,9 +19,9 @@ pub trait Codec<T>: Links {
     fn try_from_code(code: u64) -> Option<Self> where Self: Sized;
 
     /// Decode a reader into the desired type.
-    fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error>;
+    fn decode<R: BufRead>(&self, reader: R) -> Result<T, Self::Error>;
     /// Encode a type into a writer.
-    fn encode<W: Write>(writer: W, data: &T) -> Result<(), Self::Error>;
+    fn encode<W: Write>(&self, writer: W, data: &T) -> Result<(), Self::Error>;
 
     /// Decode a slice into the desired type.
     fn decode_from_slice(bytes: &[u8]) -> Result<T, Self::Error> {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -42,5 +42,5 @@ pub trait Links {
     type LinksError;
 
     /// Return all links (CIDs) that the given encoded data contains.
-    fn links(bytes: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError>;
+    fn links(&self, bytes: &[u8]) -> Result<impl Iterator<Item = Cid>, Self::LinksError>;
 }


### PR DESCRIPTION
@vmx I'm happy to update the `serde_ipld_*` instances (which are all currently broken in the test suite), but I wanted to at least propose this change in case there was some reason to not do it.

Note that the tests will currently fail because they pull in downstream libs (e.g. `serde_ipld_dagcbor`) which would need to be updated, so there's a bit of a chicken and egg situation.

# Rationale

From the docs:

> Each IPLD codec implementation should implement this Codec trait. **_This way codecs can be more easily exchanged or combined._** [emphasis mine]

I've been through this exact design loop in one of my own library modules that plugged holes in `libipld` in many of the same ways that `ipld-core` does. Essentially, if the goal is to make codecs composable (e.g. "I support both DAG-CBOR and DAG-JSON and want to model that as 'a codec'"), then `const CODE` doesn't let these stack because it requires runtime information.

## Proposal

I propose (per this PR) that `Codec` uses a `fn` instead of a `const` to make this dynamic.

```rust
// AFAIK this is impossible to write a `Codec` instance for with `const CODE`
#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
pub enum TotalCodec {
    /// DAG-CBOR
    #[default]
    DagCbor,

    /// DAG-JSON
    DagJson,
}

// Proposed
impl Codec for TotalCodec {
    fn to_code(&self) -> u64 {
      self.to_code()
    }

    // ...
}
```

It's entirely possible that I'm interpreting this line incorrectly, but I've run into this in one of my libraries that I'm switching from `libipld` to `ipld-core` ahead of IPFS Camp.

# Another Option

Changing from `const CODE: u64` to `fn code(&self) -> u64` may have a (very minor) performance implication (assuming that the compiler can't elide this on simple instances). Another option would be to have something like the following...

```rust
// Pseudocode

trait HasStaticCode {
    const CODE: u64

    // ...decode, encode, etc
}

impl<T: HasStaticCode> Codec for T {
    fn to_code(&self) -> u64 {
      Self::CODE
    }

    // ...decode, encode, etc
}
```

...which gives you the ability to restrict to the static variant, but this feels like an over optimisation _to me_.

# `from_code`

I _also_ have uses for a `from_code` as well. Right now I'm hacking it in with `TryFrom<u64>`, but `u64` and a codec are isomorphic. I see no reason to not put it right on `Codec`, but you will know much more about the overall design philosophy for `ipld-core` :)