### PR TITLE
chore(deps): use ranged version for cid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable]
+        cid: ["0.10.1", "0.11.1"]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -27,6 +28,9 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt, clippy
+
+      - name: setup cid version
+        run: cargo update --package cid --precise ${{ matrix.cid }}
 
       - name: Check code format
         run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cid",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipld-core"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Volker Mische <volker.mische@gmail.com>"
 ]
@@ -22,7 +22,7 @@ arb = ["dep:quickcheck", "cid/arb"]
 codec = []
 
 [dependencies]
-cid = { version = "0.11.1", default-features = false, features = ["alloc"] }
+cid = { version = ">=0.10,<0.12", default-features = false, features = ["alloc", "serde-codec"] }
 quickcheck = { version = "1.0", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["alloc"], optional = true }
 serde_bytes = { version = "0.11.5", default-features = false, optional = true }


### PR DESCRIPTION
(Follow up https://github.com/multiformats/rust-cid/pull/165)
This PR changes cid version to `>=0.10,<0.12` to allow projects migrating from `libipld` to `ipld-core` without upgrading `cid`