### PR TITLE
feat!: remove strict length check on tuple deserialization

### DIFF
--- a/src/ipld.rs
+++ b/src/ipld.rs
@@ -149,13 +149,13 @@ pub enum IpldIndex<'a> {
     MapRef(&'a str),
 }
 
-impl<'a> From<usize> for IpldIndex<'a> {
+impl From<usize> for IpldIndex<'_> {
     fn from(index: usize) -> Self {
         Self::List(index)
     }
 }
 
-impl<'a> From<String> for IpldIndex<'a> {
+impl From<String> for IpldIndex<'_> {
     fn from(key: String) -> Self {
         Self::Map(key)
     }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -413,17 +413,11 @@ impl<'de> de::Deserializer<'de> for Ipld {
 
     fn deserialize_tuple<V: de::Visitor<'de>>(
         self,
-        len: usize,
+        _len: usize,
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
         match self {
-            Self::List(list) => {
-                if len == list.len() {
-                    visit_seq(list, visitor)
-                } else {
-                    error(format!("The tuple size must match the length of the `Ipld::List`, tuple size: {}, `Ipld::List` length: {}", len, list.len()))
-                }
-            }
+            Self::List(list) => visit_seq(list, visitor),
             _ => error(format!(
                 "Only `Ipld::List` can be deserialized to tuple, input was `{:#?}`",
                 self


### PR DESCRIPTION
This should be handled by #[serde(deny_unknown_fields)] so it can also be used non-strict (for custom visitors/deserializers). Unfortunately this isn't supported upstream in serde yet, so we should work on that.