### PR TITLE
refactor: size_hint_cautious doesn't need to be generic

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -163,7 +163,7 @@ impl<'de> de::Deserialize<'de> for Ipld {
             where
                 V: de::SeqAccess<'de>,
             {
-                let capacity = super::size_hint_cautious::<Ipld>(visitor.size_hint().unwrap_or(0));
+                let capacity = super::size_hint_cautious(visitor.size_hint().unwrap_or(0));
                 let mut vec = Vec::with_capacity(capacity);
 
                 while let Some(elem) = visitor.next_element()? {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -163,7 +163,7 @@ impl<'de> de::Deserialize<'de> for Ipld {
             where
                 V: de::SeqAccess<'de>,
             {
-                let capacity = super::size_hint_cautious(visitor.size_hint().unwrap_or(0));
+                let capacity = super::size_hint_cautious_ipld(visitor.size_hint().unwrap_or(0));
                 let mut vec = Vec::with_capacity(capacity);
 
                 while let Some(elem) = visitor.next_element()? {

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -9,6 +9,8 @@ mod ser;
 use alloc::string::{String, ToString};
 use core::{fmt, mem};
 
+use crate::ipld::Ipld;
+
 pub use de::from_ipld;
 pub use extract_links::ExtractLinks;
 pub use ser::{to_ipld, Serializer};
@@ -39,9 +41,9 @@ impl serde::ser::StdError for SerdeError {}
 
 // Limit the the number of bytes that are used for preallocating `Vec`s. This follows what Serde is
 // doing internally with `serde::private::size_hint::cautious()`.
-fn size_hint_cautious<T>(size_hint: usize) -> usize {
+fn size_hint_cautious(size_hint: usize) -> usize {
     const MAX_PREALLOC_BYTES: usize = 1024 * 1024;
-    size_hint.min(MAX_PREALLOC_BYTES / mem::size_of::<T>())
+    size_hint.min(MAX_PREALLOC_BYTES / mem::size_of::<Ipld>())
 }
 
 #[cfg(test)]

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -41,7 +41,7 @@ impl serde::ser::StdError for SerdeError {}
 
 // Limit the the number of bytes that are used for preallocating `Vec`s. This follows what Serde is
 // doing internally with `serde::private::size_hint::cautious()`.
-fn size_hint_cautious(size_hint: usize) -> usize {
+fn size_hint_cautious_ipld(size_hint: usize) -> usize {
     const MAX_PREALLOC_BYTES: usize = 1024 * 1024;
     size_hint.min(MAX_PREALLOC_BYTES / mem::size_of::<Ipld>())
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -254,7 +254,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        let capacity = super::size_hint_cautious::<Ipld>(len.unwrap_or(0));
+        let capacity = super::size_hint_cautious(len.unwrap_or(0));
         Ok(SerializeVec {
             vec: Vec::with_capacity(capacity),
         })
@@ -279,7 +279,7 @@ impl serde::Serializer for Serializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        let capacity = super::size_hint_cautious::<Ipld>(len);
+        let capacity = super::size_hint_cautious(len);
         Ok(SerializeTupleVariant {
             name: String::from(variant),
             vec: Vec::with_capacity(capacity),

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -254,7 +254,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        let capacity = super::size_hint_cautious(len.unwrap_or(0));
+        let capacity = super::size_hint_cautious_ipld(len.unwrap_or(0));
         Ok(SerializeVec {
             vec: Vec::with_capacity(capacity),
         })
@@ -279,7 +279,7 @@ impl serde::Serializer for Serializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        let capacity = super::size_hint_cautious(len);
+        let capacity = super::size_hint_cautious_ipld(len);
         Ok(SerializeTupleVariant {
             name: String::from(variant),
             vec: Vec::with_capacity(capacity),


### PR DESCRIPTION
The `size_hint_cautious()` function doesn't need to be generic as it's always used with the `Ipld` struct. Hence just hard-code it.